### PR TITLE
Add group enable/disable toggle

### DIFF
--- a/backend/lib/database.rb
+++ b/backend/lib/database.rb
@@ -43,7 +43,8 @@ class Database
       create_domains_table unless @db.tables.include?(:domains)
       create_dns_processing_log_table unless @db.tables.include?(:dns_processing_log)
       create_settings_table unless @db.tables.include?(:settings)
-      
+      add_enabled_column_to_groups
+
       # Drop routes and sync_log tables if they exist (no longer needed - routes stored on Keenetic)
       @db.drop_table(:routes) if @db.tables.include?(:routes)
       @db.drop_table(:sync_log) if @db.tables.include?(:sync_log)
@@ -112,11 +113,21 @@ class Database
         String :description
         DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP
         DateTime :updated_at, default: Sequel::CURRENT_TIMESTAMP
-        
+
         index :key
       end
     rescue => e
       puts "Warning: Could not create settings table: #{e.message}"
+      raise e unless e.message.include?('already exists')
+    end
+
+    def add_enabled_column_to_groups
+      return if @db[:domain_groups].columns.include?(:enabled)
+      @db.alter_table(:domain_groups) do
+        add_column :enabled, TrueClass, default: true, null: false
+      end
+    rescue => e
+      puts "Warning: Could not add enabled column to domain_groups: #{e.message}"
       raise e unless e.message.include?('already exists')
     end
 

--- a/backend/lib/database.rb
+++ b/backend/lib/database.rb
@@ -43,7 +43,7 @@ class Database
       create_domains_table unless @db.tables.include?(:domains)
       create_dns_processing_log_table unless @db.tables.include?(:dns_processing_log)
       create_settings_table unless @db.tables.include?(:settings)
-      add_enabled_column_to_groups
+      add_enabled_column_to_groups if @db.tables.include?(:domain_groups)
 
       # Drop routes and sync_log tables if they exist (no longer needed - routes stored on Keenetic)
       @db.drop_table(:routes) if @db.tables.include?(:routes)

--- a/backend/lib/keenetic_master/follow_dns_logs.rb
+++ b/backend/lib/keenetic_master/follow_dns_logs.rb
@@ -229,6 +229,7 @@ class KeeneticMaster
 
       # Find domain groups that have follow_dns domains
       DomainGroup.all.each do |group|
+        next unless group.enabled != false  # skip disabled groups
         follow_dns_domains = group.domains_dataset.where(type: 'follow_dns').map(:domain)
         next if follow_dns_domains.empty?
 

--- a/backend/lib/keenetic_master/follow_dns_logs.rb
+++ b/backend/lib/keenetic_master/follow_dns_logs.rb
@@ -229,7 +229,7 @@ class KeeneticMaster
 
       # Find domain groups that have follow_dns domains
       DomainGroup.all.each do |group|
-        next unless group.enabled != false  # skip disabled groups
+        next if group.enabled == false
         follow_dns_domains = group.domains_dataset.where(type: 'follow_dns').map(:domain)
         next if follow_dns_domains.empty?
 

--- a/backend/lib/keenetic_master/update_routes_database.rb
+++ b/backend/lib/keenetic_master/update_routes_database.rb
@@ -24,6 +24,11 @@ class KeeneticMaster
         return Failure(message: "Domain group '#{group_name}' not found")
       end
 
+      if group.enabled == false
+        @logger.info("Skipping disabled group '#{group_name}'")
+        return Success(group: group_name, added: 0, deleted: 0, message: "Group '#{group_name}' is disabled, skipped")
+      end
+
       begin
         result = @routes_manager.push_group_routes!(group)
         
@@ -62,6 +67,8 @@ class KeeneticMaster
       }
 
       DomainGroup.all.each do |group|
+        next if group.enabled == false
+
         begin
           result = call(group.name)
           

--- a/backend/lib/keenetic_master/web_server.rb
+++ b/backend/lib/keenetic_master/web_server.rb
@@ -312,6 +312,42 @@ class KeeneticMaster
           end
         end
 
+        # Handle enabled toggle
+        routes_deleted = nil
+        if request_body.key?('enabled')
+          new_enabled = request_body['enabled'] != false
+          was_enabled = group.enabled != false
+
+          if was_enabled && !new_enabled
+            # Disabling: delete this group's routes from the router
+            router_routes_result = GetAllRoutes.new.call
+            if router_routes_result.success?
+              comment_pattern = /\[auto:#{Regexp.escape(group.name)}\]/
+              group_routes = router_routes_result.value!.select do |route|
+                comment_pattern.match?(route[:comment] || '')
+              end
+
+              if group_routes.any?
+                routes_to_delete = group_routes.map do |r|
+                  { network: r[:network] || r[:dest], mask: r[:mask] || r[:genmask] || '255.255.255.255', comment: r[:comment] }
+                end
+                delete_result = DeleteRoutes.call(routes_to_delete)
+                routes_deleted = group_routes.size
+                if delete_result.success?
+                  logger.info("Deleted #{routes_deleted} routes from router for disabled group '#{group.name}'")
+                else
+                  logger.warn("Failed to delete routes for disabled group '#{group.name}': #{delete_result.failure}")
+                end
+              end
+            else
+              logger.warn("Could not fetch router routes when disabling group '#{group.name}'")
+            end
+          end
+
+          group.update(enabled: new_enabled)
+          logger.info("Domain group #{group_id} enabled set to #{new_enabled}")
+        end
+
         # If interface changed, push routes to router to update them with new interface
         push_result = nil
         if interface_changed
@@ -329,6 +365,7 @@ class KeeneticMaster
         end
 
         response_data = { success: true, message: "Domain group updated successfully" }
+        response_data[:routes_deleted] = routes_deleted if routes_deleted
         if interface_changed && push_result
           if push_result.success?
             response_data[:routes_updated] = push_result.value!

--- a/backend/lib/keenetic_master/web_server.rb
+++ b/backend/lib/keenetic_master/web_server.rb
@@ -332,8 +332,8 @@ class KeeneticMaster
                   { network: r[:network] || r[:dest], mask: r[:mask] || r[:genmask] || '255.255.255.255', comment: r[:comment] }
                 end
                 delete_result = DeleteRoutes.call(routes_to_delete)
-                routes_deleted = group_routes.size
                 if delete_result.success?
+                  routes_deleted = group_routes.size
                   logger.info("Deleted #{routes_deleted} routes from router for disabled group '#{group.name}'")
                 else
                   logger.warn("Failed to delete routes for disabled group '#{group.name}': #{delete_result.failure}")

--- a/backend/lib/keenetic_master/web_server.rb
+++ b/backend/lib/keenetic_master/web_server.rb
@@ -172,6 +172,7 @@ class KeeneticMaster
             name: group.name,
             mask: group.mask,
             interfaces: group.interfaces,
+            enabled: group.enabled != false,
             domains: domains_hash,
             statistics: {
               total_domains: group.domains_dataset.where(type: 'follow_dns').count,

--- a/backend/spec/keenetic_master/update_routes_database_spec.rb
+++ b/backend/spec/keenetic_master/update_routes_database_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe KeeneticMaster::UpdateRoutesDatabase do
+  include Dry::Monads[:result]
+
+  let(:updater) { described_class.new }
+
+  describe '#call (single group)' do
+    context 'when group is disabled' do
+      let(:group) { instance_double(DomainGroup, name: 'test', enabled: false) }
+
+      before do
+        allow(DomainGroup).to receive(:find).with(name: 'test').and_return(group)
+        allow(updater).to receive(:logger).and_return(double(info: true, warn: true, error: true))
+      end
+
+      it 'returns success with skipped message' do
+        result = updater.call('test')
+        expect(result).to be_success
+        expect(result.value![:message]).to include('disabled')
+      end
+
+      it 'does not call RouterRoutesManager' do
+        routes_manager = instance_double(KeeneticMaster::RouterRoutesManager)
+        allow(KeeneticMaster::RouterRoutesManager).to receive(:new).and_return(routes_manager)
+        expect(routes_manager).not_to receive(:push_group_routes!)
+        updater.call('test')
+      end
+    end
+
+    context 'when group does not exist' do
+      before do
+        allow(DomainGroup).to receive(:find).with(name: 'missing').and_return(nil)
+        allow(updater).to receive(:logger).and_return(double(info: true, warn: true, error: true))
+      end
+
+      it 'returns failure' do
+        result = updater.call('missing')
+        expect(result).to be_failure
+      end
+    end
+  end
+
+  describe '#call_all' do
+    let(:enabled_group) { instance_double(DomainGroup, name: 'enabled_grp', enabled: true) }
+    let(:disabled_group) { instance_double(DomainGroup, name: 'disabled_grp', enabled: false) }
+
+    before do
+      allow(DomainGroup).to receive(:all).and_return([enabled_group, disabled_group])
+      allow(updater).to receive(:logger).and_return(double(info: true, warn: true, error: true))
+      allow(updater).to receive(:call).with('enabled_grp').and_return(
+        Success(group: 'enabled_grp', added: 1, deleted: 0, message: 'ok')
+      )
+    end
+
+    it 'skips disabled groups' do
+      expect(updater).not_to receive(:call).with('disabled_grp')
+      updater.call_all
+    end
+
+    it 'processes enabled groups' do
+      expect(updater).to receive(:call).with('enabled_grp').and_return(
+        Success(group: 'enabled_grp', added: 1, deleted: 0, message: 'ok')
+      )
+      updater.call_all
+    end
+  end
+end

--- a/frontend/src/components/DomainGroups.tsx
+++ b/frontend/src/components/DomainGroups.tsx
@@ -17,6 +17,7 @@ const DomainGroups: React.FC = () => {
   const [showDeleteAutoModal, setShowDeleteAutoModal] = useState(false);
   const [deletingAutoRoutes, setDeletingAutoRoutes] = useState(false);
   const [routerInterfaces, setRouterInterfaces] = useState<Array<{ id: string; description: string; name: string }>>([]);
+  const [togglingGroup, setTogglingGroup] = useState<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchTermRef = useRef<string>('');
 
@@ -156,6 +157,25 @@ const DomainGroups: React.FC = () => {
     setGroupToDelete(null);
   };
 
+  const handleToggleEnabled = useCallback(async (group: DomainGroup) => {
+    setTogglingGroup(group.id);
+    try {
+      await apiService.toggleDomainGroup(group.id, !group.enabled);
+      showNotification(
+        'success',
+        group.enabled
+          ? `Group "${group.name}" disabled. Router routes deleted.`
+          : `Group "${group.name}" enabled.`
+      );
+      await loadDomainGroups();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      showNotification('error', `Failed to toggle group: ${errorMessage}`);
+    } finally {
+      setTogglingGroup(null);
+    }
+  }, [loadDomainGroups, showNotification]);
+
   const clearSearch = () => {
     setSearchTerm('');
   };
@@ -292,12 +312,16 @@ const DomainGroups: React.FC = () => {
                         <th>IP Routes</th>
                         <th>Interface</th>
                         <th>Last Updated</th>
+                        <th>Status</th>
                         <th>Actions</th>
                       </tr>
                     </thead>
                     <tbody>
                       {(Array.isArray(filteredGroups) ? filteredGroups : []).map((group) => (
-                        <tr key={group.id}>
+                        <tr
+                          key={group.id}
+                          style={group.enabled === false ? { opacity: 0.5 } : undefined}
+                        >
                           <td>
                             <Link
                               to={`/groups/${group.name}`}
@@ -347,6 +371,17 @@ const DomainGroups: React.FC = () => {
                             ) : (
                               <span className="text-muted">-</span>
                             )}
+                          </td>
+                          <td>
+                            <Form.Check
+                              type="switch"
+                              id={`toggle-${group.id}`}
+                              checked={group.enabled !== false}
+                              disabled={togglingGroup === group.id}
+                              onChange={() => handleToggleEnabled(group)}
+                              label=""
+                              title={group.enabled !== false ? 'Enabled — click to disable' : 'Disabled — click to enable'}
+                            />
                           </td>
                           <td>
                             <div className="btn-group">

--- a/frontend/src/components/GroupDetails.tsx
+++ b/frontend/src/components/GroupDetails.tsx
@@ -34,6 +34,7 @@ const GroupDetails: React.FC = () => {
   const [deletingRoutes, setDeletingRoutes] = useState(false);
   const [pushingRoutes, setPushingRoutes] = useState(false);
   const [deletingWrongInterfaceRoutes, setDeletingWrongInterfaceRoutes] = useState(false);
+  const [togglingEnabled, setTogglingEnabled] = useState(false);
 
   useEffect(() => {
     const loadGroupDetails = async () => {
@@ -484,6 +485,29 @@ const GroupDetails: React.FC = () => {
     }
   };
 
+  const handleToggleEnabled = async () => {
+    if (!group) return;
+    setTogglingEnabled(true);
+    try {
+      await apiService.toggleDomainGroup(group.id, !group.enabled);
+      showNotification(
+        'success',
+        group.enabled !== false
+          ? `Group "${group.name}" disabled. Router routes deleted.`
+          : `Group "${group.name}" enabled.`
+      );
+      // Reload group data to reflect new state
+      const allGroups = await apiService.getDomainGroups();
+      const updated = allGroups.find(g => g.name === group.name);
+      if (updated) setGroup(updated);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      showNotification('error', `Failed to toggle group: ${errorMessage}`);
+    } finally {
+      setTogglingEnabled(false);
+    }
+  };
+
   const handleDeleteWrongInterfaceRoutes = async () => {
     if (!groupName) return;
 
@@ -616,7 +640,16 @@ const GroupDetails: React.FC = () => {
                 </h1>
               )}
             </div>
-            <div>
+            <div className="d-flex align-items-center">
+              <Form.Check
+                type="switch"
+                id="toggle-group-enabled"
+                checked={group.enabled !== false}
+                disabled={togglingEnabled}
+                onChange={handleToggleEnabled}
+                label={group.enabled !== false ? 'Enabled' : 'Disabled'}
+                className="me-2"
+              />
               <Link to="/" className="btn btn-outline-secondary me-2">
                 <i className="fas fa-arrow-left me-1"></i>
                 Back to Groups

--- a/frontend/src/components/GroupDetails.tsx
+++ b/frontend/src/components/GroupDetails.tsx
@@ -55,6 +55,7 @@ const GroupDetails: React.FC = () => {
           const convertedGroup: DomainGroup = {
             id: 0, // We don't have the ID from this API
             name: groupName,
+            enabled: true,
             mask: individualGroupData.settings?.mask || null,
             interfaces: individualGroupData.settings?.interfaces || null,
             domains: individualGroupData,
@@ -372,6 +373,7 @@ const GroupDetails: React.FC = () => {
         const convertedGroup: DomainGroup = {
           id: group.id,
           name: group.name,
+          enabled: group.enabled,
           mask: individualGroupData.settings?.mask || null,
           interfaces: individualGroupData.settings?.interfaces || null,
           domains: individualGroupData,
@@ -421,6 +423,7 @@ const GroupDetails: React.FC = () => {
         const convertedGroup: DomainGroup = {
           id: group.id,
           name: group.name,
+          enabled: group.enabled,
           mask: individualGroupData.settings?.mask || null,
           interfaces: individualGroupData.settings?.interfaces || null,
           domains: individualGroupData,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -32,6 +32,7 @@ export interface DomainGroup {
   name: string;
   mask?: string;
   interfaces?: string;
+  enabled: boolean;
   domains: any;
   statistics: {
     total_domains: number;
@@ -119,6 +120,11 @@ export const apiService = {
 
   updateDomainGroupById: async (id: number, data: { name?: string; mask?: string; interfaces?: string }): Promise<any> => {
     const response = await api.put(`/api/domain-groups/${id}`, data);
+    return response.data;
+  },
+
+  toggleDomainGroup: async (id: number, enabled: boolean): Promise<any> => {
+    const response = await api.put(`/api/domain-groups/${id}`, { enabled });
     return response.data;
   },
 


### PR DESCRIPTION
## Summary

- Add `enabled` boolean column to `domain_groups` table (default `true`, idempotent migration)
- `GET /api/domain-groups` now exposes `enabled` field
- `PUT /api/domain-groups/:id` handles `enabled` toggle — deletes router routes when a group is disabled
- `FollowDnsLogs` skips disabled groups so their domains are not monitored for DNS changes
- `UpdateRoutesDatabase` skips disabled groups in both single-group and all-groups route pushes
- Frontend: toggle switch added to groups list (with row opacity dimming) and group details header
- TypeScript: `DomainGroup` interface includes `enabled: boolean`; new `toggleDomainGroup` API method
- RSpec: new spec for disabled group skipping in `UpdateRoutesDatabase`